### PR TITLE
Fix compare_exchange_weak misuse causing incorrect read timestamp advancement

### DIFF
--- a/libraries/NeoGraph/src/neo_transaction.cpp
+++ b/libraries/NeoGraph/src/neo_transaction.cpp
@@ -30,12 +30,16 @@ namespace container {
     void TransactionManager::finish_commit(uint64_t timestamp) {
         // read_timestamp + 1 only when read_timestamp = timestamp - 1, CAS
         auto target = timestamp - 1;
-        while(!read_timestamp.compare_exchange_weak(target, timestamp, std::memory_order_relaxed)) {
+        while (true) {
+            auto temp_target = target; // Copy for CAS
+            if (read_timestamp.compare_exchange_weak(temp_target, timestamp, std::memory_order_relaxed)) {
+                break; // Success
+            }
         }
     }
 
     uint64_t TransactionManager::get_read_timestamp() const {
-        return read_timestamp;
+        return read_timestamp.load();
     }
 
     WriteTransaction* TransactionManager::get_write_transaction() {


### PR DESCRIPTION
close #8

As paper said

> Advancing the Read Timestamp: 𝑊0 polls the global read timestamp 𝑡𝑟. If 𝑡𝑟 = 𝑡 − 1, it atomically increments 𝑡𝑟 by 1. This step ensures that write queries commit in the serial order determined by their commit timestamps. The condition 𝑡𝑟 = 𝑡 − 1 enforces that writes with earlier timestamps have already advanced 𝑡𝑟, thereby preventing out-of-order commits

However, the current transaction model is incomplete, target can be modified in `compare_exchange_weak`, which means can not ensure correctness.
refer https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange.html

> Atomically compares the [object representation](https://en.cppreference.com/w/cpp/language/objects.html)(until C++20)[value representation](https://en.cppreference.com/w/cpp/language/objects.html)(since C++20) of *this with that of expected. If those are bitwise-equal, replaces the former with desired (performs read-modify-write operation). Otherwise, loads the actual value stored in *this into expected (performs load operation).